### PR TITLE
New "filling rate" option for basic control over entropy level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ With the following options being available:
 
 It also provides a few randomization options:
 
+- **--fillingRate=VAL**: sets the randomizing algorithm step filling rate with VAL from 0.0 to 1.0 (default 0.20)
 - **--shuffleTrees**: if set, Tibor trees connections are shuffled
 - **--noArmorUpgrades**: disable armor upgrades and replace them with random vanilla armors
 - **--noRecordBook**: disable the Record Book in inventory allowing to save anywhere

--- a/src/RandomizerOptions.cpp
+++ b/src/RandomizerOptions.cpp
@@ -20,12 +20,13 @@ RandomizerOptions::RandomizerOptions(const ArgumentDictionary& args)
 			}
 
 			_seed = std::stoul(tokens.at(1));
-			_armorUpgrades = (tokens.at(2) == "t");
-			_shuffleTiborTrees = (tokens.at(3) == "t");
-			_saveAnywhereBook = (tokens.at(4) == "t");
-			_spawnLocation = spawnLocationFromString(tokens.at(5));
-			_dungeonSignHints = (tokens.at(6) == "t");
-			_allowSpoilerLog = (tokens.at(7) == "t");
+			_fillingRate = std::stod(tokens.at(2));
+			_armorUpgrades = (tokens.at(3) == "t");
+			_shuffleTiborTrees = (tokens.at(4) == "t");
+			_saveAnywhereBook = (tokens.at(5) == "t");
+			_spawnLocation = spawnLocationFromString(tokens.at(6));
+			_dungeonSignHints = (tokens.at(7) == "t");
+			_allowSpoilerLog = (tokens.at(8) == "t");
 		} 
 		catch(std::exception&) {
 			throw RandomizerException("Invalid permalink given.");
@@ -42,7 +43,14 @@ RandomizerOptions::RandomizerOptions(const ArgumentDictionary& args)
 			_seed *= _seed;
 		}
 
-		// Seed-related options (included in permalink)
+		// Seed-related options (included in permalink)  
+		constexpr double DEFAULT_FILLING_RATE = 0.20;
+		try { 
+			_fillingRate = std::stod(args.getString("fillingrate", std::to_string(DEFAULT_FILLING_RATE)));
+		}
+		catch (std::invalid_argument&) {
+			_fillingRate = DEFAULT_FILLING_RATE;
+		}
 		_armorUpgrades			= args.getBoolean("armorupgrades", true);
 		_shuffleTiborTrees		= args.getBoolean("shuffletrees", false);
 		_saveAnywhereBook		= args.getBoolean("recordbook", true);
@@ -93,6 +101,7 @@ std::string RandomizerOptions::getPermalink() const
 	std::ostringstream permalinkBuilder;
 	permalinkBuilder 	<< MAJOR_RELEASE << ";"
 						<< _seed << ";"
+						<< (std::to_string(_fillingRate)) << ";"
 						<< (_armorUpgrades ? "t" : "") << ";"
 						<< (_shuffleTiborTrees ? "t" : "") << ";"
 						<< (_saveAnywhereBook ? "t" : "") << ";"

--- a/src/RandomizerOptions.hpp
+++ b/src/RandomizerOptions.hpp
@@ -30,6 +30,7 @@ public:
 	const std::string getHUDColor() const { return _hudColor; }
 
 	// Seed-related options (included in permalink)
+	double getFillingRate() const { return _fillingRate; }
 	bool useArmorUpgrades() const { return _armorUpgrades; }
 	bool shuffleTiborTrees() const { return _shuffleTiborTrees; }
 	bool useRecordBook() const { return _saveAnywhereBook; }
@@ -49,6 +50,7 @@ private:
 	bool _addIngameItemTracker;
 	std::string _hudColor;
 
+	double _fillingRate;
 	bool _armorUpgrades;
 	bool _shuffleTiborTrees;
 	bool _saveAnywhereBook;

--- a/src/SpoilerLog.hpp
+++ b/src/SpoilerLog.hpp
@@ -49,6 +49,7 @@ public:
 		*this << "Permalink: " << _options.getPermalink() << "\n";
 		*this << "Hash: " << _options.getHashSentence() << "\n\n";
 
+		*this << "Filling rate: " << std::to_string(_options.getFillingRate()) << "\n";
 		*this << "Armor upgrades: " << (_options.useArmorUpgrades() ? "enabled" : "disabled") << "\n";
 		*this << "Randomized Tibor trees: " << (_options.shuffleTiborTrees() ? "enabled" : "disabled") << "\n";
 		*this << "Record Book: " << (_options.useRecordBook() ? "enabled" : "disabled") << "\n";

--- a/src/WorldRandomizer.cpp
+++ b/src/WorldRandomizer.cpp
@@ -107,8 +107,6 @@ void WorldRandomizer::randomizeDarkRooms()
 
 void WorldRandomizer::randomizeItems()
 {
-	constexpr double FILLING_RATE = 0.20;
-
 	_regionsToExplore.insert(_world.regions[RegionCode::MASSAN]);
 	_exploredRegions.clear();		// Regions already processed by the exploration algorithm
 	_itemSourcesToFill.clear();		// Reachable empty item sources which must be filled with a random item
@@ -142,7 +140,7 @@ void WorldRandomizer::randomizeItems()
 		// Fill a fraction of already available sources with filler items
 		if (!_itemSourcesToFill.empty())
 		{
-			size_t sourcesToFillCount = (size_t)(_itemSourcesToFill.size() * FILLING_RATE);
+			size_t sourcesToFillCount = (size_t)(_itemSourcesToFill.size() * _options.getFillingRate());
 			this->placeFillerItemsPhase(sourcesToFillCount);
 		}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 //		--noPause				===> Don't ask to press a key at the end of generation (useful for automated generation systems)
 //
 //	Randomization options:
+//		--fillingRate			===> Set the randomizing algorithm step filling rate from 0.0 to 1.0 (default 0.20)
 //		--shuffleTrees			===> Randomize Tibor trees
 //		--noArmorUpgrades		===> Don't use armor upgrades, just place vanilla armors randomly
 //		--spawnLocation			===> Spawn point between Massan, Gumi and Ryuma


### PR DESCRIPTION
Initiating this PR to discuss the branch's content.

The implementation works as expected, with successful results visible in the seed's log file, especially regarding end-game items :  
- A very high filling rate puts end-game items in end-game regions only
- A very low filling rate puts end-game items anywhere really :D
For more details the debug.log file also shows well the varying number of item sources filled at each step of the randomizing algorithm.

This option is included in the permalink generation/parsing process, also tested successfully.